### PR TITLE
Anpassungen Main.js, so dass in den Gruppen EXTERNAL und INTERNAL ein…

### DIFF
--- a/main.js
+++ b/main.js
@@ -894,6 +894,10 @@ class HmIpCloudAccesspointAdapter extends utils.Adapter {
                 promises.push(this.secureSetStateAsync('groups.' + group.id + '.on', group.on, true));
                 break;
             }
+	    case 'SECURITY_ZONE': {
+		promises.push(this.secureSetStateAsync('groups.' + group.id + '.active', group.active, true));
+                break;
+            }			
         }
 
         return Promise.all(promises);
@@ -1499,6 +1503,10 @@ class HmIpCloudAccesspointAdapter extends utils.Adapter {
                 promises.push(this.setObjectNotExistsAsync('groups.' + group.id + '.on', { type: 'state', common: { name: 'on', type: 'boolean', role: 'switch', read: true, write: true }, native: { } }));
                 break;
             }
+            case 'SECURITY_ZONE' : {
+                promises.push(this.setObjectNotExistsAsync('groups.' + group.id + '.active', { type: 'state', common: { name: 'active', type: 'boolean', role: 'indicator', read: true, write: false }, native: {} }));
+                break;
+            }			
         }
 
         return Promise.all(promises);


### PR DESCRIPTION
…e Eigenschaft Active für die Alarmzonen existiert

Die Gruppen INTERNAL und EXTERNAL stellen die Alarmzustände Hüllschutz und Vollschutz dar. Anpassung der Main.js damit dort bei den Gruppen INTERNAL und EXTERNAL ein Bool vorhanden ist, welcher darstellt, ob der Hüll/Vollschutz aktiv ist.
Über diesen Weg ist der Zustandes der Alarmkomponente (ob aktiviert, und welcher Modus), relativ einfach anderweitig (Skripte, VIS usw.) nutzbar.