### PR TITLE
Add support for Homematic Home Control Unit (HCU)

### DIFF
--- a/api/hmCloudAPI.js
+++ b/api/hmCloudAPI.js
@@ -175,6 +175,7 @@ class HmCloudAPI {
             VERSION: '12',
             AUTHTOKEN: this._authToken,
             CLIENTAUTH: this._clientAuthToken,
+            "ACCESSPOINT-ID": this._accessPointSgtin,
         };
         try {
             const response = await axios.post(`${this._urlREST}/hmip/${path}`, data, { headers });

--- a/api/hmCloudAPI.js
+++ b/api/hmCloudAPI.js
@@ -222,6 +222,7 @@ class HmCloudAPI {
             headers: {
                 AUTHTOKEN: this._authToken,
                 CLIENTAUTH: this._clientAuthToken,
+                "ACCESSPOINT-ID": this._accessPointSgtin,
             },
             perMessageDeflate: false,
         });

--- a/api/hmCloudAPI.js
+++ b/api/hmCloudAPI.js
@@ -91,6 +91,7 @@ class HmCloudAPI {
             accept: 'application/json',
             VERSION: '12',
             CLIENTAUTH: this._clientAuthToken,
+            "ACCESSPOINT-ID": this._accessPointSgtin,
         };
         if (this._pin) {
             headers['PIN'] = this._pin;
@@ -118,8 +119,9 @@ class HmCloudAPI {
             accept: 'application/json',
             VERSION: '12',
             CLIENTAUTH: this._clientAuthToken,
+            "ACCESSPOINT-ID": this._accessPointSgtin,
         };
-        const body = { deviceId: this._deviceId };
+        const body = { deviceId: this._deviceId, accessPointId: this._accessPointSgtin };
         try {
             await axios.post(`${this._urlREST}/hmip/auth/isRequestAcknowledged`, body, {
                 headers,
@@ -140,6 +142,7 @@ class HmCloudAPI {
             accept: 'application/json',
             VERSION: '12',
             CLIENTAUTH: this._clientAuthToken,
+            "ACCESSPOINT-ID": this._accessPointSgtin,
         };
         let body = { deviceId: this._deviceId };
         let res;


### PR DESCRIPTION
adding accesspoint id to headers and data to make it work with HCU.
Press button once before starting the token creation. The press button again when asked for it.