### PR TITLE
feat: support DISTANCE_SENSOR_CHANNEL and FLOOR_TERMINAL_BLOCK_CHANNEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ https://forum.iobroker.net/topic/27532/homematic-ip-cloud-access-point-adapter
 -->
 ## Changelog
 ### **WORK IN PROGRESS**
-- (@Apollon77) Added the DISTANCE_SENSOR_CHANNEL, so the ELV-SH-DUSI ultrasonic distance sensor interface reports distance, calculatedHeight, referenceHeight, heightActivated, measuringInterval and distanceSensorVoltage
+- (@Apollon77) Added the DISTANCE_SENSOR_CHANNEL, so the ELV-SH-DUSI ultrasonic distance sensor interface reports distance, calculatedHeight and referenceHeight in cm, measuringInterval in minutes, heightActivated and distanceSensorVoltage
 - (@Apollon77) Added the FLOOR_TERMINAL_BLOCK_CHANNEL of the floor heating actuators (HmIP-FAL230-C6/C10, HmIP-FALMOT-C12), reporting valvePosition and the humidity limiter, dew point, external clock, emergency operation and frost protection states
 - (@Apollon77) The FLOOR_TERMINAL_BLOCK_LOCAL_PUMP_CHANNEL now reports those same states in addition to its pump times
 - (@Apollon77) The SINGLE_KEY_CHANNEL now reports acousticSendStateEnabled, actionParameter, doorBellSensorEventTimestamp, doublePressTime and visibleChannelIndex

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ https://forum.iobroker.net/topic/27532/homematic-ip-cloud-access-point-adapter
     ### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+- (@Apollon77) Added the DISTANCE_SENSOR_CHANNEL, so the ELV-SH-DUSI ultrasonic distance sensor interface reports distance, calculatedHeight, referenceHeight, heightActivated, measuringInterval and distanceSensorVoltage
+- (@Apollon77) Added the FLOOR_TERMINAL_BLOCK_CHANNEL of the floor heating actuators (HmIP-FAL230-C6/C10, HmIP-FALMOT-C12), reporting valvePosition and the humidity limiter, dew point, external clock, emergency operation and frost protection states
+- (@Apollon77) The FLOOR_TERMINAL_BLOCK_LOCAL_PUMP_CHANNEL now reports those same states in addition to its pump times
+- (@Apollon77) The SINGLE_KEY_CHANNEL now reports acousticSendStateEnabled, actionParameter, doorBellSensorEventTimestamp, doublePressTime and visibleChannelIndex
+
 ### 3.1.1 (2026-08-29)
 - (@Apollon77) Added functionalHomes.securityAndAlarm.securityZonesArmedMode, internalZoneArmed and externalZoneArmed, so the armed state of the alarm system is readable on the home instead of only on the security zone group
 - (@Apollon77) Added functionalHomes.securityAndAlarm.activateSecurityZones: write OFF, PRESENCE, ABSENCE, INTERNAL, EXTERNAL or INTERNAL_AND_EXTERNAL to arm or disarm. Every mode works on both the classic and the request-based dashboard

--- a/lib/channelStates.js
+++ b/lib/channelStates.js
@@ -465,12 +465,12 @@ const CHANNEL_STATES = {
     },
     DISTANCE_SENSOR_CHANNEL: {
         states: {
-            calculatedHeight: { type: 'number', role: 'value' },
-            distance: { type: 'number', role: 'value.distance' },
+            calculatedHeight: { type: 'number', role: 'value', unit: 'cm' },
+            distance: { type: 'number', role: 'value.distance', unit: 'cm' },
             distanceSensorVoltage: { type: 'string', role: 'text' },
             heightActivated: { type: 'boolean', role: 'indicator' },
-            measuringInterval: { type: 'number', role: 'value' },
-            referenceHeight: { type: 'number', role: 'value' },
+            measuringInterval: { type: 'number', role: 'value', unit: 'min' },
+            referenceHeight: { type: 'number', role: 'value', unit: 'cm' },
         },
     },
     DOOR_CHANNEL: {

--- a/lib/channelStates.js
+++ b/lib/channelStates.js
@@ -463,6 +463,16 @@ const CHANNEL_STATES = {
             },
         },
     },
+    DISTANCE_SENSOR_CHANNEL: {
+        states: {
+            calculatedHeight: { type: 'number', role: 'value' },
+            distance: { type: 'number', role: 'value.distance' },
+            distanceSensorVoltage: { type: 'string', role: 'text' },
+            heightActivated: { type: 'boolean', role: 'indicator' },
+            measuringInterval: { type: 'number', role: 'value' },
+            referenceHeight: { type: 'number', role: 'value' },
+        },
+    },
     DOOR_CHANNEL: {
         states: {
             doorCommand: {
@@ -695,7 +705,19 @@ const CHANNEL_STATES = {
             switchVisualization: { type: 'string', role: 'text' },
         },
     },
+    FLOOR_TERMINAL_BLOCK_CHANNEL: {
+        states: {
+            dewPointAlarmActive: { type: 'boolean', role: 'indicator' },
+            emergencyOperationActive: { type: 'boolean', role: 'indicator' },
+            externalClockActive: { type: 'boolean', role: 'indicator' },
+            frostProtectionActive: { type: 'boolean', role: 'indicator' },
+            humidityLimiterAlarm: { type: 'boolean', role: 'indicator' },
+            humidityLimiterPreAlarm: { type: 'boolean', role: 'indicator' },
+            valvePosition: { type: 'number', role: 'valve', unit: '%', derive: 'percent' },
+        },
+    },
     FLOOR_TERMINAL_BLOCK_LOCAL_PUMP_CHANNEL: {
+        extends: 'FLOOR_TERMINAL_BLOCK_CHANNEL',
         states: {
             pumpFollowUpTime: { type: 'number', role: 'value' },
             pumpLeadTime: { type: 'number', role: 'value' },
@@ -996,7 +1018,7 @@ const CHANNEL_STATES = {
                 states: { NORMALLY_CLOSE: 'NORMALLY_CLOSE', NORMALLY_OPEN: 'NORMALLY_OPEN' },
             },
             corrosionPreventionActive: { type: 'boolean', role: 'indicator' },
-            doorBellSensorEventTimestamp: { type: 'number', role: 'date' },
+            doorBellSensorEventTimestamp: { type: 'number', role: 'value.time' },
             multiModeInputMode: {
                 type: 'string',
                 role: 'text',
@@ -1409,7 +1431,12 @@ const CHANNEL_STATES = {
     },
     SINGLE_KEY_CHANNEL: {
         states: {
+            acousticSendStateEnabled: { type: 'boolean', role: 'indicator' },
+            actionParameter: { type: 'string', role: 'text' },
+            doorBellSensorEventTimestamp: { type: 'number', role: 'value.time' },
+            doublePressTime: { type: 'number', role: 'value', unit: 's' },
             on: { type: 'boolean', role: 'indicator' },
+            visibleChannelIndex: { type: 'number', role: 'value' },
         },
     },
     SMOKE_DETECTOR: {

--- a/test/fixtures/expectedChannels.json
+++ b/test/fixtures/expectedChannels.json
@@ -4666,6 +4666,103 @@
             "userDesiredProfileMode": "OPEN"
         }
     },
+    "DISTANCE_SENSOR_CHANNEL": {
+        "channel": {
+            "functionalChannelType": "DISTANCE_SENSOR_CHANNEL",
+            "groups": [
+                "GRP-A",
+                "GRP-B"
+            ],
+            "calculatedHeight": 0.5,
+            "distance": 0.5,
+            "distanceSensorVoltage": "OPEN",
+            "heightActivated": true,
+            "measuringInterval": 0.5,
+            "referenceHeight": 0.5
+        },
+        "objects": {
+            "calculatedHeight": {
+                "common": {
+                    "name": "calculatedHeight",
+                    "type": "number",
+                    "role": "value",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "distance": {
+                "common": {
+                    "name": "distance",
+                    "type": "number",
+                    "role": "value.distance",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "distanceSensorVoltage": {
+                "common": {
+                    "name": "distanceSensorVoltage",
+                    "type": "string",
+                    "role": "text",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "heightActivated": {
+                "common": {
+                    "name": "heightActivated",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "measuringInterval": {
+                "common": {
+                    "name": "measuringInterval",
+                    "type": "number",
+                    "role": "value",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "referenceHeight": {
+                "common": {
+                    "name": "referenceHeight",
+                    "type": "number",
+                    "role": "value",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            }
+        },
+        "values": {
+            "calculatedHeight": 0.5,
+            "distance": 0.5,
+            "distanceSensorVoltage": "OPEN",
+            "heightActivated": true,
+            "measuringInterval": 0.5,
+            "referenceHeight": 0.5
+        }
+    },
     "DOOR_CHANNEL": {
         "channel": {
             "functionalChannelType": "DOOR_CHANNEL",
@@ -5183,6 +5280,118 @@
             "impulsesPerKWH": 0.5
         }
     },
+    "FLOOR_TERMINAL_BLOCK_CHANNEL": {
+        "channel": {
+            "functionalChannelType": "FLOOR_TERMINAL_BLOCK_CHANNEL",
+            "groups": [
+                "GRP-A",
+                "GRP-B"
+            ],
+            "dewPointAlarmActive": true,
+            "emergencyOperationActive": true,
+            "externalClockActive": true,
+            "frostProtectionActive": true,
+            "humidityLimiterAlarm": true,
+            "humidityLimiterPreAlarm": true,
+            "valvePosition": 0.5
+        },
+        "objects": {
+            "dewPointAlarmActive": {
+                "common": {
+                    "name": "dewPointAlarmActive",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "emergencyOperationActive": {
+                "common": {
+                    "name": "emergencyOperationActive",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "externalClockActive": {
+                "common": {
+                    "name": "externalClockActive",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "frostProtectionActive": {
+                "common": {
+                    "name": "frostProtectionActive",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "humidityLimiterAlarm": {
+                "common": {
+                    "name": "humidityLimiterAlarm",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "humidityLimiterPreAlarm": {
+                "common": {
+                    "name": "humidityLimiterPreAlarm",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "valvePosition": {
+                "common": {
+                    "name": "valvePosition",
+                    "type": "number",
+                    "role": "valve",
+                    "unit": "%",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            }
+        },
+        "values": {
+            "dewPointAlarmActive": true,
+            "emergencyOperationActive": true,
+            "externalClockActive": true,
+            "frostProtectionActive": true,
+            "humidityLimiterAlarm": true,
+            "humidityLimiterPreAlarm": true,
+            "valvePosition": 50
+        }
+    },
     "FLOOR_TERMINAL_BLOCK_LOCAL_PUMP_CHANNEL": {
         "channel": {
             "functionalChannelType": "FLOOR_TERMINAL_BLOCK_LOCAL_PUMP_CHANNEL",
@@ -5190,12 +5399,104 @@
                 "GRP-A",
                 "GRP-B"
             ],
+            "dewPointAlarmActive": true,
+            "emergencyOperationActive": true,
+            "externalClockActive": true,
+            "frostProtectionActive": true,
+            "humidityLimiterAlarm": true,
+            "humidityLimiterPreAlarm": true,
             "pumpFollowUpTime": 0.5,
             "pumpLeadTime": 0.5,
             "pumpProtectionDuration": 0.5,
-            "pumpProtectionSwitchingInterval": 0.5
+            "pumpProtectionSwitchingInterval": 0.5,
+            "valvePosition": 0.5
         },
         "objects": {
+            "dewPointAlarmActive": {
+                "common": {
+                    "name": "dewPointAlarmActive",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "emergencyOperationActive": {
+                "common": {
+                    "name": "emergencyOperationActive",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "externalClockActive": {
+                "common": {
+                    "name": "externalClockActive",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "frostProtectionActive": {
+                "common": {
+                    "name": "frostProtectionActive",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "humidityLimiterAlarm": {
+                "common": {
+                    "name": "humidityLimiterAlarm",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "humidityLimiterPreAlarm": {
+                "common": {
+                    "name": "humidityLimiterPreAlarm",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "valvePosition": {
+                "common": {
+                    "name": "valvePosition",
+                    "type": "number",
+                    "role": "valve",
+                    "unit": "%",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
             "pumpFollowUpTime": {
                 "common": {
                     "name": "pumpFollowUpTime",
@@ -5246,6 +5547,13 @@
             }
         },
         "values": {
+            "dewPointAlarmActive": true,
+            "emergencyOperationActive": true,
+            "externalClockActive": true,
+            "frostProtectionActive": true,
+            "humidityLimiterAlarm": true,
+            "humidityLimiterPreAlarm": true,
+            "valvePosition": 50,
             "pumpFollowUpTime": 0.5,
             "pumpLeadTime": 0.5,
             "pumpProtectionDuration": 0.5,
@@ -6199,7 +6507,7 @@
                 "common": {
                     "name": "doorBellSensorEventTimestamp",
                     "type": "number",
-                    "role": "date",
+                    "role": "value.time",
                     "read": true,
                     "write": false
                 },
@@ -8580,9 +8888,63 @@
                 "GRP-A",
                 "GRP-B"
             ],
-            "on": true
+            "acousticSendStateEnabled": true,
+            "actionParameter": "OPEN",
+            "doorBellSensorEventTimestamp": 0.5,
+            "doublePressTime": 0.5,
+            "on": true,
+            "visibleChannelIndex": 0.5
         },
         "objects": {
+            "acousticSendStateEnabled": {
+                "common": {
+                    "name": "acousticSendStateEnabled",
+                    "type": "boolean",
+                    "role": "indicator",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "actionParameter": {
+                "common": {
+                    "name": "actionParameter",
+                    "type": "string",
+                    "role": "text",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "doorBellSensorEventTimestamp": {
+                "common": {
+                    "name": "doorBellSensorEventTimestamp",
+                    "type": "number",
+                    "role": "value.time",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
+            "doublePressTime": {
+                "common": {
+                    "name": "doublePressTime",
+                    "type": "number",
+                    "role": "value",
+                    "unit": "s",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
+            },
             "on": {
                 "common": {
                     "name": "on",
@@ -8594,10 +8956,27 @@
                 "native": {
                     "parameter": null
                 }
+            },
+            "visibleChannelIndex": {
+                "common": {
+                    "name": "visibleChannelIndex",
+                    "type": "number",
+                    "role": "value",
+                    "read": true,
+                    "write": false
+                },
+                "native": {
+                    "parameter": null
+                }
             }
         },
         "values": {
-            "on": true
+            "acousticSendStateEnabled": true,
+            "actionParameter": "OPEN",
+            "doorBellSensorEventTimestamp": 0.5,
+            "doublePressTime": 0.5,
+            "on": true,
+            "visibleChannelIndex": 0.5
         }
     },
     "SMOKE_DETECTOR": {

--- a/test/fixtures/expectedChannels.json
+++ b/test/fixtures/expectedChannels.json
@@ -4686,6 +4686,7 @@
                     "name": "calculatedHeight",
                     "type": "number",
                     "role": "value",
+                    "unit": "cm",
                     "read": true,
                     "write": false
                 },
@@ -4698,6 +4699,7 @@
                     "name": "distance",
                     "type": "number",
                     "role": "value.distance",
+                    "unit": "cm",
                     "read": true,
                     "write": false
                 },
@@ -4734,6 +4736,7 @@
                     "name": "measuringInterval",
                     "type": "number",
                     "role": "value",
+                    "unit": "min",
                     "read": true,
                     "write": false
                 },
@@ -4746,6 +4749,7 @@
                     "name": "referenceHeight",
                     "type": "number",
                     "role": "value",
+                    "unit": "cm",
                     "read": true,
                     "write": false
                 },


### PR DESCRIPTION
Addresses #1069 and #1057. Both issues report a channel type the adapter logs as `unknown channel type`, so the device publishes only `functionalChannelType` and none of its readings.

## DISTANCE_SENSOR_CHANNEL (#1069)

ELV-SH-DUSI (modelId 639) with the DUS1 ultrasonic distance sensor. New states on the channel: `distance`, `calculatedHeight`, `referenceHeight` (cm), `measuringInterval` (min), `heightActivated`, `distanceSensorVoltage`.

The units are not in the payload, but the two reported payloads pin them down. Both carry `referenceHeight: 650`, which is the DUS1's full 6.5 m range and the default the ELV documentation uses; `distance` was 174.3 and 31.9, and the sensor's minimum range is 250 mm, so mm is ruled out and cm fits both. `calculatedHeight = referenceHeight - distance` holds in both payloads. The measuring interval is documented as settable from one minute to one hour, and the observed 1, 10 and 15 fit that; `SOIL_MOISTURE_SENSOR_INTERFACE_CHANNEL` already uses `min` for the field of the same name.

`heightActivated`, `referenceHeight` and `measuringInterval` are configuration and are presumably writable, but no cloud endpoint for them is known, so they are read-only. `distanceSensorVoltage` gets no `states` map because only `SENSOR_VOLTAGE_3_3` has ever been observed.

## FLOOR_TERMINAL_BLOCK_CHANNEL (#1057)

HmIP-FAL230-C6/C10 and HmIP-FALMOT-C12. New states: `valvePosition` (the cloud sends a 0..1 fraction, reported as 0..100 % like every other valve in the table), `humidityLimiterAlarm`, `humidityLimiterPreAlarm`, `externalClockActive`, `dewPointAlarmActive`, `emergencyOperationActive`, `frostProtectionActive`.

The `FLOOR_TERMINAL_BLOCK_LOCAL_PUMP_CHANNEL` of the same devices carries those seven fields as well and was dropping them, so it now `extends` the new type on top of its pump times.

## SINGLE_KEY_CHANNEL

From a HmIP-WGC payload reported alongside: the channel published only `on`. It now also reports `acousticSendStateEnabled`, `actionParameter`, `doorBellSensorEventTimestamp`, `doublePressTime` (the four fields `homematicip-rest-api` maps) and `visibleChannelIndex`. `doorBellSensorEventTimestamp` used the `date` role here and `value.time` on `EXTERNAL_DOORBELL_CHANNEL`; both now use `value.time`.

## Tests

`test/fixtures/expectedChannels.json` gains snapshot entries for the two new channel types and is regenerated for the three changed ones. `npm run test:js` (252 passing) and `npm run lint` are clean locally; `test:package` and `test:gui` are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)